### PR TITLE
feat: limits the number of created log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ You can specify any of [Sonic-Boom options](https://github.com/pinojs/sonic-boom
   Numerical values will be considered as a number of milliseconds.
   Using a numerical value will always create a new file upon startup.
 
-* `extension?` appends the provided string after the file number.
+* `extension?`: appends the provided string after the file number.
+
+* `limit?`: strategy used to remove oldest files when rotating them:
+
+* `limit.count?`: number of log files, **in addition to the currently used file**.
+
+Please not that `limit` only considers **created log files**. It will not consider any pre-existing files.
+Therefore, starting your logger with a limit will never tries deleting older log files, created during previous executions.
 
 ## License
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { readdir, stat } = require('fs/promises')
+const { readdir, stat, unlink } = require('fs/promises')
 const { dirname, join } = require('path')
 
 function parseSize (size) {
@@ -38,6 +38,17 @@ function parseFrequency (frequency) {
     throw new Error(`${frequency} is neither a supported frequency or a number of milliseconds`)
   }
   return null
+}
+
+function validateLimitOptions (limit) {
+  if (limit) {
+    if (typeof limit !== 'object') {
+      throw new Error('limit must be an object')
+    }
+    if (typeof limit.count !== 'number' || limit.count <= 0) {
+      throw new Error('limit.count must be a number greater than 0')
+    }
+  }
 }
 
 function getNextDay (start) {
@@ -81,7 +92,7 @@ async function detectLastNumber (fileName, time = null) {
 async function readFileTrailingNumbers (folder, time) {
   const numbers = [1]
   for (const file of await readdir(folder)) {
-    if (time && !await isMatchingTime(join(folder, file), time)) {
+    if (time && !(await isMatchingTime(join(folder, file), time))) {
       continue
     }
     const number = extractTrailingNumber(file)
@@ -102,4 +113,25 @@ async function isMatchingTime (filePath, time) {
   return birthtimeMs >= time
 }
 
-module.exports = { buildFileName, detectLastNumber, parseFrequency, getNext, parseSize }
+async function checkFileRemoval (files, { count }) {
+  if (files.length > count) {
+    for (const file of files.splice(0, files.length - 1 - count)) {
+      try {
+        await unlink(file)
+      } catch {
+        // ignore delection issues
+      }
+    }
+  }
+  return files
+}
+
+module.exports = {
+  buildFileName,
+  checkFileRemoval,
+  detectLastNumber,
+  parseFrequency,
+  getNext,
+  parseSize,
+  validateLimitOptions
+}

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -5,7 +5,7 @@ const { writeFile, rm, stat } = require('fs/promises')
 const { join } = require('path')
 const { test } = require('tap')
 
-const { buildFileName, detectLastNumber, getNext, parseFrequency, parseSize } = require('../../lib/utils')
+const { buildFileName, detectLastNumber, getNext, parseFrequency, parseSize, validateLimitOptions } = require('../../lib/utils')
 const { cleanAndCreateFolder, sleep } = require('../utils')
 
 test('parseSize()', async ({ equal, throws }) => {
@@ -101,4 +101,13 @@ test('detectLastNumber()', async ({ test, beforeEach }) => {
     await rm(folder, { force: true, recursive: true })
     equal(await detectLastNumber(join(folder, 'file')), 1, 'returns 1')
   })
+})
+
+test('validateLimitOptions()', async ({ doesNotThrow, throws }) => {
+  doesNotThrow(() => validateLimitOptions(), 'allows no limit')
+  doesNotThrow(() => validateLimitOptions({ count: 2 }), 'allows valid count')
+  throws(() => validateLimitOptions(true), { message: 'limit must be an object' }, 'throws when limit is not an object')
+  throws(() => validateLimitOptions({ count: [] }), { message: 'limit.count must be a number greater than 0' }, 'throws when limit.count is not an number')
+  throws(() => validateLimitOptions({ count: -2 }), { message: 'limit.count must be a number greater than 0' }, 'throws when limit.count is negative')
+  throws(() => validateLimitOptions({ count: 0 }), { message: 'limit.count must be a number greater than 0' }, 'throws when limit.count is 0')
 })

--- a/test/pino-roll.test.js
+++ b/test/pino-roll.test.js
@@ -63,12 +63,79 @@ test('resume writing in last file', async ({ equal, rejects }) => {
   stream.write(newContent)
   await sleep(10)
 
-  equal(await readFile(`${file}.6`, 'utf8'), `${previousContent}${newContent}`, 'old and new content were written')
+  equal(
+    await readFile(`${file}.6`, 'utf8'),
+    `${previousContent}${newContent}`,
+    'old and new content were written'
+  )
   rejects(stat(`${file}.1`), 'no other files created')
 })
 
+test('remove files based on count', async ({ ok, rejects }) => {
+  const file = join(logFolder, 'log')
+  const stream = await buildStream({
+    size: '20b',
+    file,
+    limit: { count: 1 }
+  })
+  for (let i = 1; i <= 5; i++) {
+    stream.write(`logged message #${i}\n`)
+    await sleep(20)
+  }
+  stream.end()
+  await stat(`${file}.2`)
+  let content = await readFile(`${file}.2`, 'utf8')
+  ok(content.includes('#3'), 'second file contains thrid log')
+  ok(content.includes('#4'), 'second file contains fourth log')
+  await stat(`${file}.3`)
+  content = await readFile(`${file}.3`, 'utf8')
+  ok(content.includes('#5'), 'third file contains fifth log')
+  await rejects(stat(`${file}.1`), 'first file was deleted')
+  await rejects(stat(`${file}.4`), 'no other files created')
+})
+
+test('do not remove pre-existing file when removing files based on count', async ({
+  ok,
+  equal,
+  rejects
+}) => {
+  const file = join(logFolder, 'log')
+  await writeFile(`${file}.1`, 'oldest content')
+  await writeFile(`${file}.2`, 'old content')
+  const stream = await buildStream({
+    size: '20b',
+    file,
+    limit: { count: 2 }
+  })
+  for (let i = 1; i <= 7; i++) {
+    stream.write(`logged message #${i}\n`)
+    await sleep(20)
+  }
+  stream.end()
+  await stat(`${file}.1`)
+  let content = await readFile(`${file}.1`, 'utf8')
+  equal(content, 'oldest content', 'oldest file was not touched')
+  await stat(`${file}.3`)
+  content = await readFile(`${file}.3`, 'utf8')
+  ok(content.includes('#3'), 'second file contains third log')
+  ok(content.includes('#4'), 'second file contains fourth log')
+  await stat(`${file}.4`)
+  content = await readFile(`${file}.4`, 'utf8')
+  ok(content.includes('#5'), 'third file contains fifth log')
+  ok(content.includes('#6'), 'third file contains sixth log')
+  await stat(`${file}.5`)
+  content = await readFile(`${file}.5`, 'utf8')
+  ok(content.includes('#7'), 'fourth file contains seventh log')
+  await rejects(stat(`${file}.2`), 'resumed file was deleted')
+  await rejects(stat(`${file}.6`), 'no other files created')
+})
+
 test('throw on missing file parameter', async ({ rejects }) => {
-  rejects(buildStream(), { message: 'No file name provided' }, 'throws on missing file parameters')
+  rejects(
+    buildStream(),
+    { message: 'No file name provided' },
+    'throws on missing file parameters'
+  )
 })
 
 test('throw on unexisting folder without mkdir', async ({ rejects }) => {
@@ -85,7 +152,7 @@ test('throw on unparseable size', async ({ rejects }) => {
   rejects(
     buildStream({ file: join(logFolder, 'log'), size }),
     { message: `${size} is not a valid size in KB, MB or GB` },
-    'throws on unexisting folder'
+    'throws on unparseable size'
   )
 })
 
@@ -93,7 +160,39 @@ test('throw on unparseable frequency', async ({ rejects }) => {
   const frequency = 'unparseable'
   rejects(
     buildStream({ file: join(logFolder, 'log'), frequency }),
-    { message: `${frequency} is neither a supported frequency or a number of milliseconds` },
-    'throws on unexisting folder'
+    {
+      message: `${frequency} is neither a supported frequency or a number of milliseconds`
+    },
+    'throws on unparseable frequency'
+  )
+})
+
+test('throw on unparseable limit object', async ({ rejects }) => {
+  rejects(
+    buildStream({ file: join(logFolder, 'log'), limit: 10 }),
+    {
+      message: 'limit must be an object'
+    },
+    'throws on limit option not being an object'
+  )
+})
+
+test('throw when limit.count is not a number', async ({ rejects }) => {
+  rejects(
+    buildStream({ file: join(logFolder, 'log'), limit: { count: true } }),
+    {
+      message: 'limit.count must be a number greater than 0'
+    },
+    'throws on limit.count not being a number'
+  )
+})
+
+test('throw when limit.count is 0', async ({ rejects }) => {
+  rejects(
+    buildStream({ file: join(logFolder, 'log'), limit: { count: 0 } }),
+    {
+      message: 'limit.count must be a number greater than 0'
+    },
+    'throws on limit.count being 0'
   )
 })


### PR DESCRIPTION
### 📖  What's in there?

Fixes #8 
This PR brings a new option, `limit.count` that limits the number of written log files in a given execution.
It does not consider pre-exiting file

### 🧪 How to test?

It is fully covered with unit tests.