### PR TITLE
feat: Add default export typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ You can specify any of [Sonic-Boom options](https://github.com/pinojs/sonic-boom
   Numerical values will be considered as a number of milliseconds.
   Using a numerical value will always create a new file upon startup.
 
-* `extension?` appends the provided string after the file number.
+* `extension?` appends the provided string *after* the file number.
+
+* `prefix?` appends the provided string *before* the file number.
 
 ## License
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,11 +62,11 @@ function getNext (frequency) {
   return getNextCustom(frequency)
 }
 
-function buildFileName (fileName, lastNumber = 1, extension) {
+function buildFileName (fileName, lastNumber = 1, extension, prefix) {
   if (!fileName) {
     throw new Error('No file name provided')
   }
-  return `${fileName}.${lastNumber}${extension ?? ''}`
+  return `${fileName}${prefix ?? ''}.${lastNumber}${extension ?? ''}`
 }
 
 async function detectLastNumber (fileName, time = null) {

--- a/pino-roll.d.ts
+++ b/pino-roll.d.ts
@@ -1,0 +1,17 @@
+import SonicBoom, {SonicBoomOpts} from "sonic-boom";
+
+export interface PinoRollOptions extends Omit<SonicBoomOpts, 'dest'> {
+    file: string
+    mkdir?: boolean
+    frequency?: 'daily' | 'hourly' | number
+    size?: number | `${string}k` | `${string}m` | `${string}g`
+    extension?: string
+    prefix?: string
+}
+
+/**
+ * Creates a Pino transport (a Sonic-boom stream) to writing into files.
+ * Automatically rolls your files based on a given frequency, size, or both.
+ */
+declare function createPinoRoll(options: PinoRollOptions): Promise<SonicBoom>
+export default createPinoRoll

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -25,6 +25,8 @@ const { buildFileName, detectLastNumber, parseSize, parseFrequency, getNext } = 
  * Using a numerical value will always create a new file upon startup.
  *
  * @property {string} extension? - When specified, appends a file extension after the file number.
+ *
+ * @property {string} prefix? - When specified, is appended to file name before file number.
  */
 
 /**
@@ -38,7 +40,7 @@ const { buildFileName, detectLastNumber, parseSize, parseFrequency, getNext } = 
  * @param {PinoRollOptions} options - to configure file destionation, and rolling rules.
  * @returns {SonicBoom} the Sonic boom steam, usabled as Pino transport.
  */
-module.exports = async function ({ file, size, frequency, extension, ...opts } = {}) {
+module.exports = async function ({ file, size, frequency, extension, prefix, ...opts } = {}) {
   const frequencySpec = parseFrequency(frequency)
 
   let number = await detectLastNumber(file, frequencySpec?.start)
@@ -46,7 +48,7 @@ module.exports = async function ({ file, size, frequency, extension, ...opts } =
   let currentSize = 0
   const maxSize = parseSize(size)
 
-  const destination = new SonicBoom({ ...opts, dest: buildFileName(file, number, extension) })
+  const destination = new SonicBoom({ ...opts, dest: buildFileName(file, number, extension, prefix) })
 
   let rollTimeout
   if (frequencySpec) {
@@ -68,7 +70,7 @@ module.exports = async function ({ file, size, frequency, extension, ...opts } =
   }
 
   function roll () {
-    destination.reopen(buildFileName(file, ++number, extension))
+    destination.reopen(buildFileName(file, ++number, extension, prefix))
   }
 
   function scheduleRoll () {

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -59,6 +59,7 @@ test('buildFileName()', async ({ equal, throws }) => {
   throws(buildFileName, 'throws on empty input')
   equal(buildFileName('my-file'), 'my-file.1', 'appends 1 by default')
   equal(buildFileName('my-file', 5, ext), 'my-file.5.json', 'appends number and extension')
+  equal(buildFileName('my-file', 5, ext, '-2024-02-23'), 'my-file-2024-02-23.5.json', 'appends number and extension and prefix')
 })
 
 test('detectLastNumber()', async ({ test, beforeEach }) => {
@@ -66,11 +67,20 @@ test('detectLastNumber()', async ({ test, beforeEach }) => {
   beforeEach(() => cleanAndCreateFolder(folder))
 
   test('given existing files', async ({ equal }) => {
-    const fileName = join(folder, 'file.5')
-    await writeFile(join(folder, 'file.1'), '')
-    await writeFile(join(folder, 'file.5'), '')
-    await writeFile(join(folder, 'file.10'), '')
-    await writeFile(join(folder, 'file.7'), '')
+    const fileName = join(folder, 'file.2024-02-23.5')
+    await writeFile(join(folder, 'file.2024-02-23.1'), '')
+    await writeFile(join(folder, 'file.2024-02-23.5'), '')
+    await writeFile(join(folder, 'file.2024-02-23.10'), '')
+    await writeFile(join(folder, 'file.2024-02-23.7'), '')
+    equal(await detectLastNumber(fileName), 10, 'detects highest existing number')
+  })
+
+  test('given existing files with prefix', async ({ equal }) => {
+    const fileName = join(folder, 'file-2024-02-23.5')
+    await writeFile(join(folder, 'file-2024-02-23.1'), '')
+    await writeFile(join(folder, 'file-2024-02-23.5'), '')
+    await writeFile(join(folder, 'file-2024-02-23.10'), '')
+    await writeFile(join(folder, 'file-2024-02-23.7'), '')
     equal(await detectLastNumber(fileName), 10, 'detects highest existing number')
   })
 


### PR DESCRIPTION
Built on #58 -- adds Typescript typings for the default pino-roll export.

Unfortunately this is **not ready** to merge due to this library using CJS-style exports which cause issues with importing in ESM-style projects. 

https://github.com/microsoft/TypeScript/issues/52086
https://github.com/microsoft/TypeScript/issues/53045

Possibly can be fixed by outputting different builds for esm and cjs and specifying in package.json (using something like [tshy](https://github.com/isaacs/tshy)) or by updating this library to be ESM on a major version bump (breaking change).